### PR TITLE
fix cc flag order for the resolver compilation

### DIFF
--- a/src/domain/executable/resolver.rs
+++ b/src/domain/executable/resolver.rs
@@ -162,12 +162,12 @@ where
     let source_path = source.into_temp_path();
 
     let output = Command::new(cc_path.as_ref())
+        .arg("-xc")
+        .arg(&source_path)
         .arg(format!("-Wl,-dynamic-linker,{}", interp.as_ref().display()))
         .arg("-ldl")
         .arg("-o")
         .arg(program_path.as_ref())
-        .arg("-xc")
-        .arg(&source_path)
         .output_with_log()?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();


### PR DESCRIPTION
# Error
```Dockerfile
FROM ubuntu:18.04

RUN apt-get update && \
	apt-get install -y cargo git
RUN git clone https://coord-e/magicpak
WORKDIR magicpak
RUN git checkout 919a2be14
RUN cargo build --release
RUN target/release/magicpak /bin/bash bundle/
```
```
Sending build context to Docker daemon   2.56kB

Step 1/7 : FROM ubuntu:18.04
 ---> 4e5021d210f6
Step 2/7 : RUN apt-get update && 	apt-get install -y cargo git
 ---> Using cache
 ---> 6ccc575204e8
Step 3/7 : RUN git clone https://github.com/coord-e/magicpak
 ---> Using cache
 ---> 6a27484cbb79
Step 4/7 : WORKDIR magicpak
 ---> Using cache
 ---> d609c551ca44
Step 5/7 : RUN git checkout 919a2be14
 ---> Using cache
 ---> a1db8725179b
Step 6/7 : RUN cargo build --release
 ---> Using cache
 ---> a42dfc87e265
Step 7/7 : RUN target/release/magicpak /bin/bash bundle/
 ---> Running in f640ab3ca8be
[ERROR] error: Error happend during the compilation of library resolver: /tmp/cc0s2LdF.o: In function `main':
.tmp85KlQR:(.text+0x38): undefined reference to `dlopen'
.tmp85KlQR:(.text+0x4f): undefined reference to `dlerror'
.tmp85KlQR:(.text+0x76): undefined reference to `dlinfo'
.tmp85KlQR:(.text+0x86): undefined reference to `dlerror'
.tmp85KlQR:(.text+0xb4): undefined reference to `dlclose'
collect2: error: ld returned 1 exit status
```
# Solution
Current code ([919a2be14](https://github.com/coord-e/magicpak/commit/919a2be14a4ff80bdc3eada0467358fdd857c0cf)) is executing `cc` with flags `-Wl,-dynamic-linker,<ld path> -o <output> -xc <source>`. I reordered this flags as `-xc <source> -Wl,-dynamic-linker,<ld path> -o <output>` to prevent above error. However, I couldn't figure out why this problem caused, sorry.