### PR TITLE
fix clippy warnings

### DIFF
--- a/src/action/compress_executable.rs
+++ b/src/action/compress_executable.rs
@@ -1,5 +1,4 @@
 use std::ffi::OsStr;
-use std::mem;
 
 use crate::base::Result;
 use crate::domain::Executable;
@@ -21,6 +20,6 @@ where
         compressed.path().display()
     );
 
-    mem::replace(exe, compressed);
+    *exe = compressed;
     Ok(())
 }

--- a/src/base/trace.rs
+++ b/src/base/trace.rs
@@ -30,8 +30,8 @@ pub trait ChildTraceExt {
         handler: SyscallHandler<FOpen, FOpenAt>,
     ) -> Result<Output>
     where
-        FOpen: FnMut(OsString, i32) -> (),
-        FOpenAt: FnMut(i32, OsString, i32) -> ();
+        FOpen: FnMut(OsString, i32),
+        FOpenAt: FnMut(i32, OsString, i32);
 }
 
 impl ChildTraceExt for Child {
@@ -40,8 +40,8 @@ impl ChildTraceExt for Child {
         mut handler: SyscallHandler<FOpen, FOpenAt>,
     ) -> Result<Output>
     where
-        FOpen: FnMut(OsString, i32) -> (),
-        FOpenAt: FnMut(i32, OsString, i32) -> (),
+        FOpen: FnMut(OsString, i32),
+        FOpenAt: FnMut(i32, OsString, i32),
     {
         use nix::sys::signal::Signal;
         use nix::sys::wait::WaitStatus;

--- a/src/domain/bundle.rs
+++ b/src/domain/bundle.rs
@@ -79,7 +79,7 @@ impl Bundle {
     {
         let entries = std::mem::take(&mut self.entries);
         let updated = entries.into_iter().filter(|(k, _)| predicate(k)).collect();
-        std::mem::replace(&mut self.entries, updated);
+        self.entries = updated;
     }
 
     pub fn emit<P>(&self, dest: P) -> Result<()>


### PR DESCRIPTION
* use direct assign instead of `std::mem::resize`
* remove unneccesary `-> ()`