### PR TITLE
Fix busybox_jail_path file permissions

### DIFF
--- a/src/domain/jail.rs
+++ b/src/domain/jail.rs
@@ -37,7 +37,7 @@ impl Jail {
             fs::create_dir(&bindir)?;
         }
         fs::copy(&busybox_path, &busybox_jail_path)?;
-        fs::set_permissions(&busybox_jail_path, fs::Permissions::from_mode(755))?;
+        fs::set_permissions(&busybox_jail_path, fs::Permissions::from_mode(0o755))?;
 
         let output = Command::new(busybox_jail_path)
             .arg("--install")


### PR DESCRIPTION
Fixes the `fs::set_permissions(&busybox_jail_path, fs::Permissions::from_mode(755))?;` line so it sets proper permissions as it seems the 755 (decimal) was intended to be 0o755 (octal).

The difference in between the two can be seen below:
```python
In [15]: os.chmod('x', 755)

In [16]: !ls -la x
--wxrw--wt  1 dc  staff  0 Aug 23 19:52 x

In [17]: os.chmod('x', 0o755)

In [18]: !ls -la x
-rwxr-xr-x  1 dc  staff  0 Aug 23 19:52 x
```

FWIW clippy should also be able to detect this.

Found thx to https://grep.app/search?q=from_mode%5C%28%5B0-9%5D%7B3%7D&regexp=true