### PR TITLE
Enable to build and run on aarch64

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-gnu-gcc"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,16 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-musl
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt-get install -y musl-tools busybox-static
+      - run: sudo apt-get install -y gcc-aarch64-linux-gnu
+        if: matrix.target == 'aarch64-unknown-linux-musl'
       - uses: actions/cache@v2
         with:
           path: |
@@ -18,19 +25,20 @@ jobs:
             ~/.cargo/git/db/
             ~/.cargo/registry/cache/
             ~/.cargo/registry/index/
-          key: "${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}"
+          key: "${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}"
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --all-features --target=x86_64-unknown-linux-musl
+          args: --release --all-features --target=${{ matrix.target }}
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --all-features --target=x86_64-unknown-linux-musl
+          args: --release --all-features --target=${{ matrix.target }}
+        if: matrix.target == 'x86_64-unknown-linux-musl'  # TODO: test aarch64
       - uses: actions/upload-artifact@v2
         with:
-          name: musl-executable
-          path: ./target/x86_64-unknown-linux-musl/release/magicpak
+          name: musl-executable-${{ matrix.target }}
+          path: ./target/${{ matrix.target }}/release/magicpak
   build_docker_images:
     name: Build and push docker images
     runs-on: ubuntu-20.04
@@ -39,7 +47,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
-          name: musl-executable
+          name: musl-executable-x86_64-unknown-linux-musl
       - run: docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} -p ${{ secrets.DOCKER_HUB_PASSWORD }}
       - uses: docker/setup-buildx-action@v1
       - run: ./dockerfile/build.sh ./magicpak
@@ -50,11 +58,16 @@ jobs:
     name: Release
     runs-on: ubuntu-20.04
     needs: build_docker_images
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-musl
     steps:
       - uses: actions/download-artifact@v2
         with:
-          name: musl-executable
-      - run: mv magicpak magicpak-x86_64-unknown-linux-musl
+          name: musl-executable-${{ matrix.target }}
+      - run: mv magicpak magicpak-${{ matrix.target }}
       - uses: softprops/action-gh-release@v1
         with:
           files: magicpak-*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,15 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        target: [x86_64-unknown-linux-musl]
+        target:
+          - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-musl
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt-get install -y musl-tools busybox-static
+      - run: sudo apt-get install -y gcc-aarch64-linux-gnu
+        if: matrix.target == 'aarch64-unknown-linux-musl'
+      - run: rustup target add ${{ matrix.target }}
       - uses: actions/cache@v2
         with:
           path: |
@@ -19,20 +24,20 @@ jobs:
             ~/.cargo/git/db/
             ~/.cargo/registry/cache/
             ~/.cargo/registry/index/
-          key: "${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}"
+          key: "${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}"
       - uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release --all-features --target=${{ matrix.target }}
       - uses: actions/upload-artifact@v2
         with:
-          name: musl-executable
-          path: ./target/x86_64-unknown-linux-musl/release/magicpak
-        if: matrix.target == 'x86_64-unknown-linux-musl'
+          name: musl-executable-${{ matrix.target }}
+          path: ./target/${{ matrix.target }}/release/magicpak
       - uses: actions-rs/cargo@v1
         with:
           command: test
           args: --release --all-features --target=${{ matrix.target }}
+        if: matrix.target == 'x86_64-unknown-linux-musl'  # TODO: test aarch64
   fmt:
     name: Rustfmt
     runs-on: ubuntu-20.04
@@ -59,7 +64,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
-          name: musl-executable
+          name: musl-executable-x86_64-unknown-linux-musl
       - uses: docker/setup-buildx-action@v1
       - name: Build docker images
         env:


### PR DESCRIPTION
ref: #5 

`magicpak::base::trace` implementation for aarch64
- `getregs` uses `PTRACE_GETREGSET` instead of `PTRACE_GETREGS`