### PR TITLE
fix: stop canonicalizing path given in --include

### DIFF
--- a/src/action/include_glob.rs
+++ b/src/action/include_glob.rs
@@ -6,7 +6,7 @@ pub fn include_glob(bundle: &mut Bundle, pattern: &str) -> Result<()> {
 
     for entry in glob::glob(pattern)? {
         match entry {
-            Ok(path) => bundle.add(path.canonicalize()?),
+            Ok(path) => bundle.add(path),
             Err(e) => tracing::warn!(error = %e, "action: include_glob: Ignoring glob match"),
         }
     }


### PR DESCRIPTION
First step for #12. Currently there is no way to manually include symlinks into the bundle and this PR makes it possible by disable canonicalization of paths in `--include`.