### PR TITLE
fix: enable static analysis on --include

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ WORKDIR /workdir
 CMD ["/bin/clang-format"]
 ```
 
+### Note on name resolution and glibc
+
+If your program uses glibc for name resolution (most likely it does), the call to getaddrinfo(3) will result in an error after bundled by magicpak.
+This can be resolved by manually including the NSS-related shared libraries as shown below.
+
+```dockerfile
+# example on x86_64 Debian-based image:
+RUN magicpak path/to/executable /bundle --include '/lib/x86_64-linux-gnu/libnss_*'
+```
+
 ## Disclaimer
 
 `magicpak` comes with absolutely no warranty. There's no guarantee that the processed bundle works properly and identically to the original executable. Although I had no problem using `magicpak` for building various kinds of images, it is recommended to use this with caution and make a careful examination of the resulting bundle.

--- a/src/action/include_glob.rs
+++ b/src/action/include_glob.rs
@@ -1,12 +1,20 @@
 use crate::base::Result;
-use crate::domain::Bundle;
+use crate::domain::{Bundle, Executable};
 
-pub fn include_glob(bundle: &mut Bundle, pattern: &str) -> Result<()> {
+pub fn include_glob(bundle: &mut Bundle, pattern: &str, cc: &str) -> Result<()> {
     tracing::info!(%pattern, "action: include using glob");
+
+    let cc_path = which::which(cc)?;
 
     for entry in glob::glob(pattern)? {
         match entry {
-            Ok(path) => bundle.add(path),
+            Ok(path) => {
+                if let Ok(obj) = Executable::load(&path) {
+                    bundle.add(obj.interpreter());
+                    bundle.add(obj.dynamic_libraries(&cc_path)?);
+                }
+                bundle.add(path);
+            }
             Err(e) => tracing::warn!(error = %e, "action: include_glob: Ignoring glob match"),
         }
     }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -127,7 +127,7 @@ fn run(args: &Args) -> Result<()> {
     }
 
     for glob in &args.include {
-        action::include_glob(&mut bundle, glob)?;
+        action::include_glob(&mut bundle, glob, &args.cc)?;
     }
 
     for glob in &args.exclude {

--- a/src/domain/executable.rs
+++ b/src/domain/executable.rs
@@ -47,7 +47,7 @@ impl Executable {
         name: String,
         propagated_rpaths: Option<Vec<PathBuf>>,
     ) -> Result<Self> {
-        tracing::info!(location = %location.as_ref().display(), "exe: loading");
+        tracing::debug!(location = %location.as_ref().display(), "exe: loading");
         let buffer = fs::read(location.as_ref())?;
         let elf = Elf::parse(buffer.as_slice())?;
         let interpreter = if let Some(interp) = elf.interpreter {
@@ -55,7 +55,7 @@ impl Executable {
         } else {
             let interp = default_interpreter(&location)?;
             if let Some(interp) = &interp {
-                tracing::info!(interp = %interp.display(), "exe: using default interpreter");
+                tracing::debug!(interp = %interp.display(), "exe: using default interpreter");
             } else {
                 tracing::warn!(
                     "exe: interpreter could not be found. static or compressed executable?"


### PR DESCRIPTION
for #12.

- Load dynamically linked libraries for ELF objects selected by `--include`
- Document to use the flag to include libnss_* libraries for applications which may use NSS