### PR TITLE
Release v1.3.2

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.aarch64-unknown-linux-musl]
-linker = "aarch64-linux-gnu-gcc"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       - run: docker buildx bake --push --set '*.cache-from=type=gha' --set '*.cache-to=type=gha,mode=max'
         env:
           BIN_DIR: "./dist"
-          VERSION: "1.3.1"
+          VERSION: "1.3.2"
   release:
     name: Release
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ name: Release
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         target:
@@ -36,7 +36,7 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-musl'  # TODO: test aarch64
   build_docker_images:
     name: Build and push docker images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: test
     steps:
       - name: Free up disk space
@@ -61,7 +61,7 @@ jobs:
           VERSION: "1.3.1"
   release:
     name: Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build_docker_images
     strategy:
       matrix:
@@ -80,7 +80,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   upload:
     name: Upload to crates.io
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: release
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - run: sudo apt-get install -y gcc-aarch64-linux-gnu
         if: matrix.target == 'aarch64-unknown-linux-musl'
       - run: rustup target add ${{ matrix.target }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             target/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
         target:
           - x86_64-unknown-linux-musl
           - aarch64-unknown-linux-musl
+    env:
+      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt-get install -y musl-tools busybox-static

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: sudo apt-get install -y musl-tools busybox-static
       - run: sudo apt-get install -y gcc-aarch64-linux-gnu
         if: matrix.target == 'aarch64-unknown-linux-musl'
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Free up disk space
         run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v2
         with:
           name: musl-executable-x86_64-unknown-linux-musl
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: release
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-buildx-action@v2
       - run: docker buildx bake --push --set '*.cache-from=type=gha' --set '*.cache-to=type=gha,mode=max'
         env:
           BIN_DIR: "./dist"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,10 @@ jobs:
       - uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64
-      - run: docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} -p ${{ secrets.DOCKER_HUB_PASSWORD }}
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       - uses: docker/setup-buildx-action@v1
       - run: docker buildx bake --push --set '*.cache-from=type=gha' --set '*.cache-to=type=gha,mode=max'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
             ~/.cargo/registry/index/
           key: "${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}"
       - run: cargo build --release --all-features --target=${{ matrix.target }} --locked
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: musl-executable-${{ matrix.target }}
           path: ./target/${{ matrix.target }}/release/magicpak

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,11 @@ jobs:
       - name: Free up disk space
         run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: musl-executable-x86_64-unknown-linux-musl
       - run: mkdir -p dist/amd64 && mv ./magicpak ./dist/amd64/magicpak
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: musl-executable-aarch64-unknown-linux-musl
       - run: mkdir -p dist/arm64 && mv ./magicpak ./dist/arm64/magicpak
@@ -74,7 +74,7 @@ jobs:
           - x86_64-unknown-linux-musl
           - aarch64-unknown-linux-musl
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: musl-executable-${{ matrix.target }}
       - run: mv magicpak magicpak-${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,18 +27,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/registry/index/
           key: "${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}"
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --all-features --target=${{ matrix.target }}
+      - run: cargo build --release --all-features --target=${{ matrix.target }}
       - uses: actions/upload-artifact@v2
         with:
           name: musl-executable-${{ matrix.target }}
           path: ./target/${{ matrix.target }}/release/magicpak
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --all-features --target=${{ matrix.target }}
+      - run: cargo test --release --all-features --target=${{ matrix.target }}
         if: matrix.target == 'x86_64-unknown-linux-musl'  # TODO: test aarch64
   build_docker_images:
     name: Build and push docker images
@@ -90,8 +84,6 @@ jobs:
     needs: release
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: publish
+      - run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/registry/index/
           key: "${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}"
-      - run: cargo build --release --all-features --target=${{ matrix.target }}
+      - run: cargo build --release --all-features --target=${{ matrix.target }} --locked
       - uses: actions/upload-artifact@v2
         with:
           name: musl-executable-${{ matrix.target }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           name: musl-executable-x86_64-unknown-linux-musl
       - run: mkdir -p dist/amd64 && mv ./magicpak ./dist/amd64/magicpak
-      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-buildx-action@v2
       - name: Build examples
         run: docker buildx bake --set '*.cache-from=type=gha' --set '*.cache-to=type=gha,mode=max' --set 'base.platform=linux/amd64' example
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
             ~/.cargo/registry/index/
           key: "${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}"
       - run: cargo build --release --all-features --target=${{ matrix.target }} --locked
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: musl-executable-${{ matrix.target }}
           path: ./target/${{ matrix.target }}/release/magicpak

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ name: Test and Lint
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         target:
@@ -34,19 +34,19 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-musl'  # TODO: test aarch64
   fmt:
     name: Rustfmt
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - run: cargo fmt --all -- --check
   clippy:
     name: Clippy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - run: cargo clippy --all-features -- -D warnings
   test_examples:
     name: Test examples
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: test
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
         target:
           - x86_64-unknown-linux-musl
           - aarch64-unknown-linux-musl
+    env:
+      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt-get install -y musl-tools busybox-static

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
     needs: test
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: musl-executable-x86_64-unknown-linux-musl
       - run: mkdir -p dist/amd64 && mv ./magicpak ./dist/amd64/magicpak

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/registry/index/
           key: "${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}"
-      - run: cargo build --release --all-features --target=${{ matrix.target }}
+      - run: cargo build --release --all-features --target=${{ matrix.target }} --locked
       - uses: actions/upload-artifact@v2
         with:
           name: musl-executable-${{ matrix.target }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: sudo apt-get install -y musl-tools busybox-static
       - run: sudo apt-get install -y gcc-aarch64-linux-gnu
         if: matrix.target == 'aarch64-unknown-linux-musl'
@@ -38,20 +38,20 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: cargo fmt --all -- --check
   clippy:
     name: Clippy
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: cargo clippy --all-features -- -D warnings
   test_examples:
     name: Test examples
     runs-on: ubuntu-22.04
     needs: test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v2
         with:
           name: musl-executable-x86_64-unknown-linux-musl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - run: sudo apt-get install -y gcc-aarch64-linux-gnu
         if: matrix.target == 'aarch64-unknown-linux-musl'
       - run: rustup target add ${{ matrix.target }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             target/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,37 +25,25 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/registry/index/
           key: "${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}"
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --all-features --target=${{ matrix.target }}
+      - run: cargo build --release --all-features --target=${{ matrix.target }}
       - uses: actions/upload-artifact@v2
         with:
           name: musl-executable-${{ matrix.target }}
           path: ./target/${{ matrix.target }}/release/magicpak
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --all-features --target=${{ matrix.target }}
+      - run: cargo test --release --all-features --target=${{ matrix.target }}
         if: matrix.target == 'x86_64-unknown-linux-musl'  # TODO: test aarch64
   fmt:
     name: Rustfmt
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
   clippy:
     name: Clippy
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features -- -D warnings
+      - run: cargo clippy --all-features -- -D warnings
   test_examples:
     name: Test examples
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,4 +61,4 @@ jobs:
         run: docker buildx bake --set '*.cache-from=type=gha' --set '*.cache-to=type=gha,mode=max' --set 'base.platform=linux/amd64' example
         env:
           BIN_DIR: ./dist
-          VERSION: 1.3.1
+          VERSION: 1.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.2] - 2022-11-23
+
+- Fix not to canonicalize paths in `--include` ([#20](https://github.com/coord-e/magicpak/pull/20))
+- Search statically linked dependencies of ELF objects specified by `--include` ([#33](https://github.com/coord-e/magicpak/pull/33))
+  - To deal with getaddrinfo(3) issue described in ([#12](https://github.com/coord-e/magicpak/issues/12))
+- Improve error messages ([#36](https://github.com/coord-e/magicpak/pull/36))
+- Dependency updates
+
 ## [1.3.1] - 2022-06-19
 
 - AArch64 support ([#14](https://github.com/coord-e/magicpak/pull/14))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,9 +308,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.117"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "log"
@@ -732,13 +732,13 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.2.4"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
 dependencies = [
  "either",
- "lazy_static",
  "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "plain"
@@ -465,11 +465,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -581,13 +581,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -630,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.30"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8d93354fe2a8e50d5953f5ae2e47a3fc2ef03292e7ea46e3cc38f549525fb9"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -642,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.19"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -653,11 +653,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.22"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
- "lazy_static",
+ "once_cell",
  "valuable",
 ]
 
@@ -693,10 +693,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unicode-ident"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "valuable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "assert_cmd"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +365,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +397,12 @@ checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pin-project-lite"
@@ -569,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "strsim"
@@ -653,19 +660,19 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.22"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
- "lazy_static",
+ "once_cell",
  "valuable",
 ]
 
 [[package]]
 name = "tracing-log"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "lazy_static",
  "log",
@@ -674,11 +681,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.7"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5312f325fe3588e277415f5a6cca1f4ccad0f248c4cd5a4bd33032d7286abc22"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
- "ansi_term",
+ "nu-ansi-term",
  "sharded-slab",
  "smallvec",
  "thread_local",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "magicpak"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,9 +401,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "predicates"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+checksum = "ed6bd09a7f7e68f3f0bf710fb7ab9c4615a488b58b5f653382a687701e458c92"
 dependencies = [
  "difflib",
  "float-cmp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,11 +22,11 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
+checksum = "ba45b8163c49ab5f972e59a8a5a03b6d2972619d486e19ec9fe744f7c2753d3c"
 dependencies = [
- "bstr",
+ "bstr 1.0.1",
  "doc-comment",
  "predicates",
  "predicates-core",
@@ -77,9 +77,19 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
 dependencies = [
- "lazy_static",
  "memchr",
+]
+
+[[package]]
+name = "bstr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca0852af221f458706eb0725c03e4ed6c46af9ac98e6a689d5e634215d594dd"
+dependencies = [
+ "memchr",
+ "once_cell",
  "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -195,7 +205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c152169ef1e421390738366d2f796655fec62621dabbd0fd476f905934061e4a"
 dependencies = [
  "aho-corasick",
- "bstr",
+ "bstr 0.2.14",
  "fnv",
  "log",
  "regex",
@@ -374,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "os_str_bytes"
@@ -541,6 +551,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "serde"
+version = "1.0.147"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 
 [[package]]
 name = "sharded-slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ nix = "0.23"
 tempfile = "3.1.0"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-which = "4.0"
+which = "4.3"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magicpak"
-version = "1.3.1"
+version = "1.3.2"
 authors = ["coord_e <me@coord-e.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ WORKDIR /workdir
 CMD ["/bin/clang-format"]
 ```
 
+### Note on name resolution and glibc
+
+If your program uses glibc for name resolution (most likely it does), the call to getaddrinfo(3) will result in an error after bundled by magicpak.
+This can be resolved by manually including the NSS-related shared libraries as shown below.
+
+```dockerfile
+# example on x86_64 Debian-based image:
+RUN magicpak path/to/executable /bundle --include '/lib/x86_64-linux-gnu/libnss_*'
+```
+
 ## Disclaimer
 
 `magicpak` comes with absolutely no warranty. There's no guarantee that the processed bundle works properly and identically to the original executable. Although I had no problem using `magicpak` for building various kinds of images, it is recommended to use this with caution and make a careful examination of the resulting bundle.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ```dockerfile
 # You prepare /bin/your_executable here...
 
-ADD https://github.com/coord-e/magicpak/releases/download/v1.3.1/magicpak-x86_64-unknown-linux-musl /usr/bin/magicpak
+ADD https://github.com/coord-e/magicpak/releases/download/v1.3.2/magicpak-x86_64-unknown-linux-musl /usr/bin/magicpak
 RUN chmod +x /usr/bin/magicpak
 
 RUN /usr/bin/magicpak -v /bin/your_executable /bundle
@@ -94,7 +94,7 @@ We provide some base images that contain `magicpak` and its optional dependencie
 The following is a dockerfile using `magicpak` for a docker image of [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html), a formatter for C/C++/etc. ([example/clang-format](/example/clang-format))
 
 ```dockerfile
-FROM magicpak/debian:buster-magicpak1.3.1
+FROM magicpak/debian:buster-magicpak1.3.2
 
 RUN apt-get -y update
 RUN apt-get -y --no-install-recommends install clang-format

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -237,20 +237,20 @@ group "example" {
 target "example-brittany" {
   dockerfile = "example/brittany/Dockerfile"
   contexts = {
-    "magicpak/haskell:8.10.2-magicpak1.3.1" = "target:haskell-8102"
+    "magicpak/haskell:8.10.2-magicpak1.3.2" = "target:haskell-8102"
   }
 }
 
 target "example-clang-format" {
   dockerfile = "example/clang-format/Dockerfile"
   contexts = {
-    "magicpak/debian:buster-magicpak1.3.1" = "target:debian-buster"
+    "magicpak/debian:buster-magicpak1.3.2" = "target:debian-buster"
   }
 }
 
 target "example-patchelf" {
   dockerfile = "example/patchelf/Dockerfile"
   contexts = {
-    "magicpak/cc:10-magicpak1.3.1" = "target:cc-10"
+    "magicpak/cc:10-magicpak1.3.2" = "target:cc-10"
   }
 }

--- a/example/brittany/Dockerfile
+++ b/example/brittany/Dockerfile
@@ -1,4 +1,4 @@
-FROM magicpak/haskell:8.10.2-magicpak1.3.1
+FROM magicpak/haskell:8.10.2-magicpak1.3.2
 
 RUN apt-get -y update
 RUN apt-get -y install unzip libtinfo5

--- a/example/clang-format/Dockerfile
+++ b/example/clang-format/Dockerfile
@@ -1,4 +1,4 @@
-FROM magicpak/debian:buster-magicpak1.3.1
+FROM magicpak/debian:buster-magicpak1.3.2
 
 RUN apt-get -y update
 RUN apt-get -y --no-install-recommends install clang-format

--- a/example/patchelf/Dockerfile
+++ b/example/patchelf/Dockerfile
@@ -1,4 +1,4 @@
-FROM magicpak/cc:10-magicpak1.3.1
+FROM magicpak/cc:10-magicpak1.3.2
 
 WORKDIR /usr/src/patchelf
 ADD https://github.com/NixOS/patchelf/archive/0.10.tar.gz patchelf.tar.gz

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.58.1"
+channel = "1.65.0"
 components = [ "rustfmt", "clippy" ]
 targets = [ "x86_64-unknown-linux-musl" ]

--- a/src/action/bundle_shared_object_dependencies.rs
+++ b/src/action/bundle_shared_object_dependencies.rs
@@ -1,4 +1,4 @@
-use crate::base::Result;
+use crate::base::{Error, Result};
 use crate::domain::{Bundle, Executable};
 
 pub fn bundle_shared_object_dependencies(
@@ -11,7 +11,7 @@ pub fn bundle_shared_object_dependencies(
         "action: bundle shared object dependencies",
     );
 
-    let cc_path = which::which(cc)?;
+    let cc_path = which::which(cc).map_err(|e| Error::ExecutableLocateFailed(cc.to_owned(), e))?;
 
     bundle.add(exe.interpreter());
     bundle.add(exe.dynamic_libraries(cc_path)?);

--- a/src/action/compress_executable.rs
+++ b/src/action/compress_executable.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsStr;
 
-use crate::base::Result;
+use crate::base::{Error, Result};
 use crate::domain::Executable;
 
 pub fn compress_exexcutable<I, S>(exe: &mut Executable, upx: &str, upx_opts: I) -> Result<()>
@@ -10,7 +10,8 @@ where
 {
     tracing::info!(exe = %exe.path().display(), "action: compress executable");
 
-    let upx_path = which::which(upx)?;
+    let upx_path =
+        which::which(upx).map_err(|e| Error::ExecutableLocateFailed(upx.to_owned(), e))?;
 
     let compressed = exe.compressed(upx_path, upx_opts)?;
     tracing::debug!(

--- a/src/action/include_glob.rs
+++ b/src/action/include_glob.rs
@@ -1,10 +1,10 @@
-use crate::base::Result;
+use crate::base::{Error, Result};
 use crate::domain::{Bundle, Executable};
 
 pub fn include_glob(bundle: &mut Bundle, pattern: &str, cc: &str) -> Result<()> {
     tracing::info!(%pattern, "action: include using glob");
 
-    let cc_path = which::which(cc)?;
+    let cc_path = which::which(cc).map_err(|e| Error::ExecutableLocateFailed(cc.to_owned(), e))?;
 
     for entry in glob::glob(pattern)? {
         match entry {

--- a/src/action/include_glob.rs
+++ b/src/action/include_glob.rs
@@ -6,7 +6,7 @@ pub fn include_glob(bundle: &mut Bundle, pattern: &str) -> Result<()> {
 
     for entry in glob::glob(pattern)? {
         match entry {
-            Ok(path) => bundle.add(path.canonicalize()?),
+            Ok(path) => bundle.add(path),
             Err(e) => tracing::warn!(error = %e, "action: include_glob: Ignoring glob match"),
         }
     }

--- a/src/action/include_glob.rs
+++ b/src/action/include_glob.rs
@@ -1,12 +1,20 @@
 use crate::base::Result;
-use crate::domain::Bundle;
+use crate::domain::{Bundle, Executable};
 
-pub fn include_glob(bundle: &mut Bundle, pattern: &str) -> Result<()> {
+pub fn include_glob(bundle: &mut Bundle, pattern: &str, cc: &str) -> Result<()> {
     tracing::info!(%pattern, "action: include using glob");
+
+    let cc_path = which::which(cc)?;
 
     for entry in glob::glob(pattern)? {
         match entry {
-            Ok(path) => bundle.add(path),
+            Ok(path) => {
+                if let Ok(obj) = Executable::load(&path) {
+                    bundle.add(obj.interpreter());
+                    bundle.add(obj.dynamic_libraries(&cc_path)?);
+                }
+                bundle.add(path);
+            }
             Err(e) => tracing::warn!(error = %e, "action: include_glob: Ignoring glob match"),
         }
     }

--- a/src/action/test.rs
+++ b/src/action/test.rs
@@ -26,7 +26,8 @@ where
 
     tracing::info!(%command, "action: test the bundle");
 
-    let busybox_path = which::which(busybox)?;
+    let busybox_path =
+        which::which(busybox).map_err(|e| Error::ExecutableLocateFailed(busybox.to_owned(), e))?;
 
     let mut test_bundle = bundle.clone();
     test_bundle.add_pseudo_proc(exe);

--- a/src/base/error.rs
+++ b/src/base/error.rs
@@ -23,6 +23,7 @@ pub enum Error {
     DynamicFailed(ExitStatus),
     Encoding(str::Utf8Error),
     PathEncoding(OsString),
+    InvalidObjectPath(PathBuf),
     IO(io::Error),
 }
 
@@ -77,6 +78,9 @@ impl fmt::Display for Error {
                 "Unable to interpret the path as UTF-8: {}",
                 p.to_string_lossy()
             ),
+            Error::InvalidObjectPath(p) => {
+                write!(f, "Invalid ELF object file path '{}'", p.display())
+            }
             Error::IO(e) => write!(f, "IO error: {}", e),
         }
     }

--- a/src/base/error.rs
+++ b/src/base/error.rs
@@ -18,7 +18,7 @@ pub enum Error {
     BusyBoxInstall(String),
     TestFailed(String),
     TestStdoutMismatch { expected: String, got: String },
-    ExecutableLocateFailed(which::Error),
+    ExecutableLocateFailed(String, which::Error),
     Upx(String),
     DynamicFailed(ExitStatus),
     Encoding(str::Utf8Error),
@@ -65,7 +65,9 @@ impl fmt::Display for Error {
                 expected, got
             ),
             Error::Encoding(e) => write!(f, "Encoding error: {}", e),
-            Error::ExecutableLocateFailed(e) => write!(f, "Unable to locate executable: {}", e),
+            Error::ExecutableLocateFailed(exe, e) => {
+                write!(f, "Unable to locate executable '{}': {}", exe, e)
+            }
             Error::Upx(e) => write!(f, "upx failed with non-zero exit code: {}", e),
             Error::DynamicFailed(status) => {
                 write!(f, "Dynamic analysis subproecss failed: {}", status)
@@ -118,11 +120,5 @@ impl From<glob::PatternError> for Error {
 impl From<nix::Error> for Error {
     fn from(err: nix::Error) -> Self {
         Error::IO(err.into())
-    }
-}
-
-impl From<which::Error> for Error {
-    fn from(err: which::Error) -> Self {
-        Error::ExecutableLocateFailed(err)
     }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -127,7 +127,7 @@ fn run(args: &Args) -> Result<()> {
     }
 
     for glob in &args.include {
-        action::include_glob(&mut bundle, glob)?;
+        action::include_glob(&mut bundle, glob, &args.cc)?;
     }
 
     for glob in &args.exclude {

--- a/src/domain/executable.rs
+++ b/src/domain/executable.rs
@@ -47,7 +47,7 @@ impl Executable {
         name: String,
         propagated_rpaths: Option<Vec<PathBuf>>,
     ) -> Result<Self> {
-        tracing::info!(location = %location.as_ref().display(), "exe: loading");
+        tracing::debug!(location = %location.as_ref().display(), "exe: loading");
         let buffer = fs::read(location.as_ref())?;
         let elf = Elf::parse(buffer.as_slice())?;
         let interpreter = if let Some(interp) = elf.interpreter {
@@ -55,7 +55,7 @@ impl Executable {
         } else {
             let interp = default_interpreter(&location)?;
             if let Some(interp) = &interp {
-                tracing::info!(interp = %interp.display(), "exe: using default interpreter");
+                tracing::debug!(interp = %interp.display(), "exe: using default interpreter");
             } else {
                 tracing::warn!(
                     "exe: interpreter could not be found. static or compressed executable?"

--- a/src/domain/executable.rs
+++ b/src/domain/executable.rs
@@ -137,7 +137,7 @@ impl Executable {
             return Ok(Vec::new());
         };
 
-        let resolver = resolver::Resolver::new(&interpreter, &self.search_paths, cc_path.as_ref())?;
+        let resolver = resolver::Resolver::new(interpreter, &self.search_paths, cc_path.as_ref())?;
 
         let mut paths = Vec::new();
         for lib in &self.libraries {

--- a/src/domain/executable.rs
+++ b/src/domain/executable.rs
@@ -3,7 +3,7 @@ use std::ffi::OsStr;
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::{env, fs, io};
+use std::{env, fs};
 
 use crate::base::log::CommandLogExt;
 use crate::base::{Error, Result};
@@ -87,13 +87,11 @@ impl Executable {
         P: AsRef<Path>,
     {
         let path = exe_path.as_ref();
-        if path.is_dir() {
-            return Err(Error::IO(io::Error::from_raw_os_error(21)));
-        }
 
         let location = ExecutableLocation::Fixed(path.to_owned());
-        // unwrap is ok because `path` here is not a directory
-        let file_name = path.file_name().unwrap();
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| Error::InvalidObjectPath(path.to_owned()))?;
         let file_name_str = file_name
             .to_str()
             .ok_or_else(|| Error::PathEncoding(file_name.to_os_string()))?


### PR DESCRIPTION
- Fix not to canonicalize paths in `--include` ([#20](https://github.com/coord-e/magicpak/pull/20))
- Search statically linked dependencies of ELF objects specified by `--include` ([#33](https://github.com/coord-e/magicpak/pull/33))
  - To deal with getaddrinfo(3) issue described in ([#12](https://github.com/coord-e/magicpak/issues/12))
- Improve error messages ([#36](https://github.com/coord-e/magicpak/pull/36))
- Dependency updates