### PR TITLE
fix: ignore already emitted symlinks

### DIFF
--- a/src/domain/bundle.rs
+++ b/src/domain/bundle.rs
@@ -279,4 +279,40 @@ mod tests {
         dest.child("b.txt").assert(predicate::path::missing());
         Ok(())
     }
+
+    #[test]
+    fn test_chained_sync_copy_link() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        // z.txt -> y.txt -> x.txt
+        // and more than one of these paths are added to bundle
+
+        let dest = assert_fs::TempDir::new()?;
+
+        let src_dir = assert_fs::TempDir::new()?;
+        let src = src_dir.child("x.txt");
+        src.touch()?;
+        src.write_str("hello")?;
+        let link1 = src_dir.child("y.txt");
+        unix::fs::symlink(src.path(), link1.path())?;
+        let link2 = src_dir.child("z.txt");
+        unix::fs::symlink(link1.path(), link2.path())?;
+
+        sync_copy(src.path(), BundlePath::projection(&src), dest.path())?;
+        sync_copy(link1.path(), BundlePath::projection(&link1), dest.path())?;
+        sync_copy(link2.path(), BundlePath::projection(&link2), dest.path())?;
+
+        assert!(matches!(
+            dest.child(link1.path()).path().read_link(),
+            Ok(link_dest)
+            if link_dest == src.path()
+        ));
+        assert!(matches!(
+            dest.child(link2.path()).path().read_link(),
+            Ok(link_dest)
+            if link_dest == link1.path()
+        ));
+        dest.child(src.path())
+            .assert(predicate::path::is_file())
+            .assert("hello");
+        Ok(())
+    }
 }


### PR DESCRIPTION
When there are two or more links transitively points to the same file and more than two of them are included to the bundle, magicpak fails with the following error (unexpected behavior):

```
error: IO error: File exists (os error 17)
```

For example, this can happen when `--include '/lib/x86_64-linux-gnu/libnss_*'` is specified.
https://github.com/coord-e/magicpak#note-on-name-resolution-and-glibc

- `/lib/x86_64-linux-gnu/libnss_dns.so` is a symlink to `/lib/x86_64-linux-gnu/libnss_dns.so.2`
- and `/lib/x86_64-linux-gnu/libnss_dns.so.2` is a symlink to `/lib/x86_64-linux-gnu/libnss_dns-2.31.so`

This PR fixes it.
