### PR TITLE
feat: implement noload resolver to avoid loading with dlopen(3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ This can be resolved by manually including the NSS-related shared libraries as s
 RUN magicpak path/to/executable /bundle --include '/lib/x86_64-linux-gnu/libnss_*'
 ```
 
+### Note on jemalloc
+
+If your program depends on libjemalloc, magicpak may fail with the following message.
+
+```
+error: Unable to lookup shared library: /lib/aarch64-linux-gnu/libjemalloc.so.2: cannot allocate memory in static TLS block
+```
+
+You can use `--experimental-noload-resolver` flag to workaround this. See [#19](https://github.com/coord-e/magicpak/issues/19) for details.
+
 ## Disclaimer
 
 `magicpak` comes with absolutely no warranty. There's no guarantee that the processed bundle works properly and identically to the original executable. Although I had no problem using `magicpak` for building various kinds of images, it is recommended to use this with caution and make a careful examination of the resulting bundle.

--- a/src/action/bundle_shared_object_dependencies.rs
+++ b/src/action/bundle_shared_object_dependencies.rs
@@ -1,10 +1,11 @@
 use crate::base::{Error, Result};
 use crate::domain::{Bundle, Executable};
 
-pub fn bundle_shared_object_dependencies(
+fn bundle_shared_object_dependencies_impl(
     bundle: &mut Bundle,
     exe: &Executable,
     cc: &str,
+    noload_resolver: bool,
 ) -> Result<()> {
     tracing::info!(
         exe = %exe.path().display(),
@@ -14,6 +15,27 @@ pub fn bundle_shared_object_dependencies(
     let cc_path = which::which(cc).map_err(|e| Error::ExecutableLocateFailed(cc.to_owned(), e))?;
 
     bundle.add(exe.interpreter());
-    bundle.add(exe.dynamic_libraries(cc_path)?);
+    if noload_resolver {
+        bundle.add(exe.dynamic_libraries_noload(cc_path)?);
+    } else {
+        bundle.add(exe.dynamic_libraries(cc_path)?);
+    }
+
     Ok(())
+}
+
+pub fn bundle_shared_object_dependencies(
+    bundle: &mut Bundle,
+    exe: &Executable,
+    cc: &str,
+) -> Result<()> {
+    bundle_shared_object_dependencies_impl(bundle, exe, cc, false)
+}
+
+pub fn bundle_shared_object_dependencies_noload(
+    bundle: &mut Bundle,
+    exe: &Executable,
+    cc: &str,
+) -> Result<()> {
+    bundle_shared_object_dependencies_impl(bundle, exe, cc, true)
 }

--- a/src/action/include_glob.rs
+++ b/src/action/include_glob.rs
@@ -1,7 +1,12 @@
 use crate::base::{Error, Result};
 use crate::domain::{Bundle, Executable};
 
-pub fn include_glob(bundle: &mut Bundle, pattern: &str, cc: &str) -> Result<()> {
+fn include_glob_impl(
+    bundle: &mut Bundle,
+    pattern: &str,
+    cc: &str,
+    noload_resolver: bool,
+) -> Result<()> {
     tracing::info!(%pattern, "action: include using glob");
 
     let cc_path = which::which(cc).map_err(|e| Error::ExecutableLocateFailed(cc.to_owned(), e))?;
@@ -11,7 +16,11 @@ pub fn include_glob(bundle: &mut Bundle, pattern: &str, cc: &str) -> Result<()> 
             Ok(path) => {
                 if let Ok(obj) = Executable::load(&path) {
                     bundle.add(obj.interpreter());
-                    bundle.add(obj.dynamic_libraries(&cc_path)?);
+                    if noload_resolver {
+                        bundle.add(obj.dynamic_libraries_noload(&cc_path)?);
+                    } else {
+                        bundle.add(obj.dynamic_libraries(&cc_path)?);
+                    }
                 }
                 bundle.add(path);
             }
@@ -20,4 +29,12 @@ pub fn include_glob(bundle: &mut Bundle, pattern: &str, cc: &str) -> Result<()> 
     }
 
     Ok(())
+}
+
+pub fn include_glob(bundle: &mut Bundle, pattern: &str, cc: &str) -> Result<()> {
+    include_glob_impl(bundle, pattern, cc, false)
+}
+
+pub fn include_glob_noload(bundle: &mut Bundle, pattern: &str, cc: &str) -> Result<()> {
+    include_glob_impl(bundle, pattern, cc, true)
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -122,6 +122,10 @@ struct Args {
     /// Specify the path or name of c compiler that would be used in
     /// the name resolution of shared library dependencies
     cc: String,
+
+    #[clap(long)]
+    /// [EXPERIMENTAL] Resolve dynamic library paths without loading in dlopen(3).
+    experimental_noload_resolver: bool,
 }
 
 fn run(args: &Args) -> Result<()> {
@@ -133,7 +137,11 @@ fn run(args: &Args) -> Result<()> {
         .collect::<Result<Vec<_>>>()?;
 
     for exe in &exes {
-        action::bundle_shared_object_dependencies(&mut bundle, exe, &args.cc)?;
+        if args.experimental_noload_resolver {
+            action::bundle_shared_object_dependencies_noload(&mut bundle, exe, &args.cc)?;
+        } else {
+            action::bundle_shared_object_dependencies(&mut bundle, exe, &args.cc)?;
+        }
     }
 
     if args.dynamic {
@@ -164,7 +172,11 @@ fn run(args: &Args) -> Result<()> {
     }
 
     for glob in &args.include {
-        action::include_glob(&mut bundle, glob, &args.cc)?;
+        if args.experimental_noload_resolver {
+            action::include_glob_noload(&mut bundle, glob, &args.cc)?;
+        } else {
+            action::include_glob(&mut bundle, glob, &args.cc)?;
+        }
     }
 
     for glob in &args.exclude {

--- a/src/domain/executable/resolver.rs
+++ b/src/domain/executable/resolver.rs
@@ -9,7 +9,7 @@ use crate::domain::executable::SearchPaths;
 
 use tempfile::NamedTempFile;
 
-static RESOLVER_SOURCE_CODE: &str = r"
+static GENERIC_RESOLVER_SOURCE_CODE: &str = r"
 #define _GNU_SOURCE
 #include <dlfcn.h>
 #include <link.h>
@@ -32,10 +32,78 @@ int main(int argc, char** argv) {
   dlclose(handle);
 }";
 
+static NOLOAD_RESOLVER_SOURCE_CODE: &str = r"
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <link.h>
+
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+  char* name = argv[1];
+  void* handle = dlopen(name, RTLD_LAZY | RTLD_NOLOAD);
+  if (handle == NULL) {
+    fputs(dlerror(), stderr);
+    return 1;
+  }
+  struct link_map* link_map;
+  if (dlinfo(handle, RTLD_DI_LINKMAP, &link_map) != 0) {
+    fputs(dlerror(), stderr);
+    return 2;
+  }
+  puts(link_map->l_name);
+  dlclose(handle);
+}";
+
+#[derive(Debug)]
+enum ResolverProgram {
+    NoLoad { interp: PathBuf, cc_path: PathBuf },
+    Generic { program_path: PathBuf },
+}
+
+impl ResolverProgram {
+    pub fn new<P, Q>(interp: P, cc_path: Q) -> Result<Self>
+    where
+        P: AsRef<Path>,
+        Q: AsRef<Path>,
+    {
+        let program_path = calc_resolver_program_path(&interp, &cc_path, "generic");
+        if !program_path.exists() {
+            build_generic_resolver_program(&program_path, &interp, &cc_path)?;
+        }
+
+        Ok(ResolverProgram::Generic { program_path })
+    }
+
+    pub fn new_noload<P, Q>(interp: P, cc_path: Q) -> Self
+    where
+        P: AsRef<Path>,
+        Q: AsRef<Path>,
+    {
+        ResolverProgram::NoLoad {
+            interp: interp.as_ref().to_owned(),
+            cc_path: cc_path.as_ref().to_owned(),
+        }
+    }
+
+    pub fn setup_for(&self, name: &str) -> Result<PathBuf> {
+        match self {
+            ResolverProgram::NoLoad { interp, cc_path } => {
+                let program_path = calc_resolver_program_path(interp, cc_path, name);
+                if !program_path.exists() {
+                    build_noload_resolver_program(&program_path, interp, cc_path, name)?;
+                }
+                Ok(program_path)
+            }
+            ResolverProgram::Generic { program_path } => Ok(program_path.clone()),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct Resolver<'a> {
-    program_path: PathBuf,
     search_paths: &'a SearchPaths,
+    program: ResolverProgram,
 }
 
 impl<'a> Resolver<'a> {
@@ -44,14 +112,23 @@ impl<'a> Resolver<'a> {
         P: AsRef<Path>,
         Q: AsRef<Path>,
     {
-        let program_path = calc_program_path(&interp, &cc_path);
-        if !program_path.exists() {
-            build_resolver_program(&program_path, &interp, &cc_path)?;
-        }
-
         let resolver = Resolver {
-            program_path,
             search_paths,
+            program: ResolverProgram::new(interp, cc_path)?,
+        };
+
+        tracing::debug!(?resolver, "resolver: created resolver");
+        Ok(resolver)
+    }
+
+    pub fn new_noload<P, Q>(interp: P, search_paths: &'a SearchPaths, cc_path: Q) -> Result<Self>
+    where
+        P: AsRef<Path>,
+        Q: AsRef<Path>,
+    {
+        let resolver = Resolver {
+            search_paths,
+            program: ResolverProgram::new_noload(interp, cc_path),
         };
 
         tracing::debug!(?resolver, "resolver: created resolver");
@@ -109,7 +186,8 @@ impl<'a> Resolver<'a> {
     }
 
     fn lookup_rest(&self, name: &str) -> Result<PathBuf> {
-        let output = Command::new(&self.program_path)
+        let program_path = self.program.setup_for(name)?;
+        let output = Command::new(&program_path)
             .arg(name)
             .env_clear()
             .output_with_log()?;
@@ -122,7 +200,7 @@ impl<'a> Resolver<'a> {
     }
 }
 
-fn calc_program_path<P, Q>(interp: P, cc_path: Q) -> PathBuf
+fn calc_resolver_program_path<P, Q>(interp: P, cc_path: Q, name: &str) -> PathBuf
 where
     P: AsRef<Path>,
     Q: AsRef<Path>,
@@ -144,20 +222,20 @@ where
 
     let mut path = env::temp_dir();
     path.push(format!(
-        "magicpak_resolver_{}_{}",
-        interp_hash, cc_path_hash
+        "magicpak_resolver_{}_{}_{}",
+        name, interp_hash, cc_path_hash
     ));
     path
 }
 
-fn build_resolver_program<P, Q, R>(program_path: P, interp: Q, cc_path: R) -> Result<()>
+fn build_generic_resolver_program<P, Q, R>(program_path: P, interp: Q, cc_path: R) -> Result<()>
 where
     P: AsRef<Path>,
     Q: AsRef<Path>,
     R: AsRef<Path>,
 {
     let mut source = NamedTempFile::new()?;
-    write!(source, "{}", RESOLVER_SOURCE_CODE)?;
+    write!(source, "{}", GENERIC_RESOLVER_SOURCE_CODE)?;
     let source_path = source.into_temp_path();
 
     let output = Command::new(cc_path.as_ref())
@@ -165,6 +243,39 @@ where
         .arg(&source_path)
         .arg(format!("-Wl,-dynamic-linker,{}", interp.as_ref().display()))
         .arg("-ldl")
+        .arg("-o")
+        .arg(program_path.as_ref())
+        .output_with_log()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(Error::ResolverCompilation(stderr));
+    }
+    source_path.close()?;
+    Ok(())
+}
+
+fn build_noload_resolver_program<P, Q, R>(
+    program_path: P,
+    interp: Q,
+    cc_path: R,
+    name: &str,
+) -> Result<()>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
+    R: AsRef<Path>,
+{
+    let mut source = NamedTempFile::new()?;
+    write!(source, "{}", NOLOAD_RESOLVER_SOURCE_CODE)?;
+    let source_path = source.into_temp_path();
+
+    let output = Command::new(cc_path.as_ref())
+        .arg("-xc")
+        .arg(&source_path)
+        .arg(format!("-Wl,-dynamic-linker,{}", interp.as_ref().display()))
+        .arg("-ldl")
+        .arg("-Wl,--no-as-needed")
+        .arg(format!("-l:{}", name))
         .arg("-o")
         .arg(program_path.as_ref())
         .output_with_log()?;


### PR DESCRIPTION
for #19 

jemalloc fails to load when loaded by dlopen(3), so current implementation fails to resolve it to the actual library path.

```
libjemalloc.so: cannot allocate memory in static TLS block
```

This PR attempts to solve this problem by not requiring loading with dlopen(3). I do not have enough time to test this, so for now I will allow this to be enabled by an experimental flag `--experimental-noload-resolver`.